### PR TITLE
Changed the cart tracking cookies to homegrown ones

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -64,6 +64,9 @@ To install and take into use the SizeMe for WooCommerce plugin, follow the instr
 
 == Changelog ==
 
+= 2.0.2 =
+* fixed bug in cart tracking
+
 = 2.0.1 =
 * added clientKey to sizeme_options
 


### PR DESCRIPTION
* it seemed that the WC's own cart identifiers are not always present when the woocommerce_add_to_cart action is fired